### PR TITLE
Update suggested param attribute order

### DIFF
--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -260,8 +260,9 @@ Coding Style
 
   *  name
   *  type
-  *  value | truevalue | falsevalue
-  *  [checked]
+  *  truevalue | falsevalue
+  *  value | checked
+  *  optional
   *  label
   *  help 
 


### PR DESCRIPTION
`value` should be an alternative to `checked` (which is used only for boolean params).
Add `optional`.