### PR TITLE
Suggestion for an order of IDs/links annotations

### DIFF
--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -289,8 +289,6 @@ Coding Style
 
   * `description`_
   * `macros`_
-  * `edam_topics`_
-  * `edam_operations`_
   * [parallelism]
   * `requirements`_
   * [code]
@@ -304,6 +302,9 @@ Coding Style
   * `outputs`_
   * `tests`_
   * `help`_
+  * `xrefs`_
+  * `edam_topics`_
+  * `edam_operations`_
   * `citations`_
 
 * Cheetah code should also be indented and mainly `PEP8`_ conformant
@@ -330,8 +331,6 @@ Coding Style
 
 .. _description: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-description
 .. _macros: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-macros
-.. _edam_topics: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-edam-topics
-.. _edam_operations: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-edam-operations
 .. _requirements: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-requirements
 .. _stdio: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-stdio
 .. _version_command: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-version-command
@@ -342,6 +341,9 @@ Coding Style
 .. _outputs: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-outputs
 .. _tests: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-tests
 .. _help: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-help
+.. _xrefs: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-xrefs
+.. _edam_topics: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-edam-topics
+.. _edam_operations: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-edam-operations
 .. _citations: https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-citations
 .. _bedtools: http://bedtools.readthedocs.org/en/latest/content/tools/slop.html
 .. _slop: https://github.com/galaxyproject/tools-iuc/blob/master/tools/bedtools/slopBed.xml


### PR DESCRIPTION
... and added the missing `xrefs`.

This is based on a chat with @bgruening in winter 2020, and is also what I've been following when annotating example IUC tools. The idea was to have all the IDs a.k.a. external links a.k.a. upstream annotation next to each other: `xrefs`, `edam_topics`, `edam_operations`, `citations`.

If the order should be changed as suggested, it might be good to also change it in:
(I volunteer if green light)
 - https://docs.galaxyproject.org/en/latest/dev/schema.html (Is that just https://github.com/galaxyproject/galaxy/blob/dev/doc/schema_template.md?)
 - https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/xsd/galaxy.xsd (Note: the XML schema itself is order-agnostic)
 - Anywhere else?