### PR TITLE
Proposal: recommend defining a @VERSION_SUFFIX@ token in addition to a @TOOL_VERSION@ token

### DIFF
--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -41,7 +41,7 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
   is preferred not to use a ``@VERSION_SUFFIX@`` token (e.g. to allow bumping
   the version only for a specific tool in a suite), the tool ``version``
   attribute should be simply set to ``@TOOL_VERSION@+galaxyN``, where N is an
-  integer following the same rules of ``@VERSION_SUFFIX@``.
+  integer following the same rules as ``@VERSION_SUFFIX@``.
 
 If instead the Galaxy tool cannot be identified with a single underlying tool,
 the ``+galaxy@VERSION_SUFFIX@`` local version identifier should be omitted, and any version

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -38,9 +38,10 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
   - to be increased by 1 whenever you update the wrapper without changing
     the underlying ``@TOOL_VERSION@``.
 - set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@VERSION_SUFFIX@``. If it
-  is preferred not to use a ``@VERSION_SUFFIX@`` token, the version suffix can be specified
-  by simply using an integer ``N``, in which case the tool ``version`` attribute should be set
-  to ``@TOOL_VERSION@+galaxyN``.
+  is preferred not to use a ``@VERSION_SUFFIX@`` token (e.g. to allow bumping
+  the version only for a specific tool in a suite), the tool ``version``
+  attribute should be simply set to ``@TOOL_VERSION@+galaxyN``, where N is an
+  integer following the same rules of ``@VERSION_SUFFIX@``.
 
 If instead the Galaxy tool cannot be identified with a single underlying tool,
 the ``+galaxy@VERSION_SUFFIX@`` local version identifier should be omitted, and any version

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -28,13 +28,17 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
 
 - define a ``@TOOL_VERSION@``
   `macro token <https://planemo.readthedocs.io/en/latest/writing_advanced.html#macro-tokens>`__,
-  which you can also re-use in the corresponding ``<requirement>`` element;
-- define a ``@VERSION_SUFFIX@`` macro token. This should be set to:
+  which you should also re-use in the corresponding ``<requirement>`` element;
+- optionally, define a ``@VERSION_SUFFIX@`` macro token, which may be placed either
+  in the tool wrapper or in a shared macro file. This should be set to:
 
   - 0 for the first wrapper release of each version of the underlying tool.
   - an integer number to be increased by 1 whenever you update the wrapper
     without changing the underlying ``@TOOL_VERSION@``.
-- set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@VERSION_SUFFIX@``.
+- set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@VERSION_SUFFIX@``. If it
+  is preferred not to use a ``@VERSION_SUFFIX@`` token, the version suffix can be specified
+  by simply using an integer ``N``, in which case the tool ``version`` attribute should be set
+  to ``@TOOL_VERSION@+galaxyN``.
 
 If instead the Galaxy tool cannot be identified with a single underlying tool,
 the ``+galaxy@VERSION_SUFFIX@`` local version identifier should be omitted, and any version

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -29,12 +29,14 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
 - define a ``@TOOL_VERSION@``
   `macro token <https://planemo.readthedocs.io/en/latest/writing_advanced.html#macro-tokens>`__,
   which you should also re-use in the corresponding ``<requirement>`` element;
-- optionally, define a ``@VERSION_SUFFIX@`` macro token, which may be placed either
-  in the tool wrapper or in a shared macro file. This should be set to:
+- optionally, define a ``@VERSION_SUFFIX@`` macro token, which may be placed
+  either in the tool wrapper or in a shared macro file. This should be set to
+  an integer number:
 
-  - 0 for the first wrapper release of each version of the underlying tool.
-  - an integer number to be increased by 1 whenever you update the wrapper
-    without changing the underlying ``@TOOL_VERSION@``.
+  - starting at 0 for the first wrapper release of each version of the
+    underlying tool;
+  - to be increased by 1 whenever you update the wrapper without changing
+    the underlying ``@TOOL_VERSION@``.
 - set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@VERSION_SUFFIX@``. If it
   is preferred not to use a ``@VERSION_SUFFIX@`` token, the version suffix can be specified
   by simply using an integer ``N``, in which case the tool ``version`` attribute should be set

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -33,7 +33,7 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
 
   - 0 for the first wrapper release of each version of the underlying tool.
   - an integer number to be increased by 1 whenever you update the wrapper
-    without changing the underlying `@TOOL_VERSION@`.
+    without changing the underlying ``@TOOL_VERSION@``.
 - set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@GALAXY_VERSION@``.
 
 If instead the Galaxy tool cannot be identified with a single underlying tool,

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -29,15 +29,15 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
 - define a ``@TOOL_VERSION@``
   `macro token <https://planemo.readthedocs.io/en/latest/writing_advanced.html#macro-tokens>`__,
   which you can also re-use in the corresponding ``<requirement>`` element;
-- define a ``@GALAXY_VERSION@`` macro token. This should be set to:
+- define a ``@VERSION_SUFFIX@`` macro token. This should be set to:
 
   - 0 for the first wrapper release of each version of the underlying tool.
   - an integer number to be increased by 1 whenever you update the wrapper
     without changing the underlying ``@TOOL_VERSION@``.
-- set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@GALAXY_VERSION@``.
+- set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@VERSION_SUFFIX@``.
 
 If instead the Galaxy tool cannot be identified with a single underlying tool,
-the ``+galaxy@GALAXY_VERSION@`` local version identifier should be omitted, and any version
+the ``+galaxy@VERSION_SUFFIX@`` local version identifier should be omitted, and any version
 value can be used, as long as it respects the PEP 440 specification.
 
 For tools whose wrapper version is (for historical reasons) already greater than

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -29,16 +29,14 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
 - define a ``@TOOL_VERSION@``
   `macro token <https://planemo.readthedocs.io/en/latest/writing_advanced.html#macro-tokens>`__,
   which you can also re-use in the corresponding ``<requirement>`` element;
-- set the tool ``version`` attribute to:
-
-  - ``@TOOL_VERSION@`` or ``@TOOL_VERSION@+galaxy0`` for the first wrapper
-    release of each version of the underlying tool;
-  - ``@TOOL_VERSION@+galaxyN`` for the following wrapper releases, where ``N``
-    is an integer number to be increased whenever you update the wrapper
-    without changing the underlying tool version.
+- define a ``@GALAXY_VERSION@`` macro token. This should be set to:
+  - 0 for the first wrapper release of each version of the underlying tool
+  - an integer number to be increased by 1 whenever you update the wrapper
+    without changing the underlying `@TOOL_VERSION@`.
+- set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@GALAXY_VERSION@``.
 
 If instead the Galaxy tool cannot be identified with a single underlying tool,
-the ``+galaxyN`` local version identifier should be omitted, and any version
+the ``+galaxy@GALAXY_VERSION@`` local version identifier should be omitted, and any version
 value can be used, as long as it respects the PEP 440 specification.
 
 For tools whose wrapper version is (for historical reasons) already greater than

--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -30,7 +30,8 @@ If the Galaxy tool is a wrapper for an underlying tool, we recommend to:
   `macro token <https://planemo.readthedocs.io/en/latest/writing_advanced.html#macro-tokens>`__,
   which you can also re-use in the corresponding ``<requirement>`` element;
 - define a ``@GALAXY_VERSION@`` macro token. This should be set to:
-  - 0 for the first wrapper release of each version of the underlying tool
+
+  - 0 for the first wrapper release of each version of the underlying tool.
   - an integer number to be increased by 1 whenever you update the wrapper
     without changing the underlying `@TOOL_VERSION@`.
 - set the tool ``version`` attribute to ``@TOOL_VERSION@+galaxy@GALAXY_VERSION@``.


### PR DESCRIPTION
Motivation: we are currently working on a `planemo autoupdate` command which automatically checks if newer versions of the `<requirements>` exist and updates them if necessary. To simplify things we want to assume that all tools have both a `@TOOL_VERSION@` and `@GALAXY_VERSION@` token specified (either in the tool xml file itself or in a macro).

It would be nice if this could also be an official IUC recommendation - any comments are welcome.