### PR TITLE
remove rule to use select for conditionals

### DIFF
--- a/docs/best_practices/tool_xml.rst
+++ b/docs/best_practices/tool_xml.rst
@@ -234,10 +234,6 @@ in the Cheetah ``<command>`` section.
         ...
         <param name=”strict” truevalue=”--enable-strict” falsevalue=””>
 
-Boolean should not be used as a conditional for other options. For dynamic
-options, please use a ``select`` input type as described in the Dynamic Options
-section below.
-
 Dynamic Options
 ---------------
 


### PR DESCRIPTION
The UI/UX group wonders if this rule is justified, i.e. are there any studies saying that it is not a good idea to have a boolean control optional parts of the form. 

Problem: we are enforcing this rule for a long time via IUC guideline and linter rules. Changing the booleans to selects is error prone and requires downstream workflows to be changed. 

See also xref https://github.com/galaxyproject/galaxy/issues/18759