### PR TITLE
Integrate follow-up documentation review

### DIFF
--- a/docs/best_practices/integration_checklist.rst
+++ b/docs/best_practices/integration_checklist.rst
@@ -78,7 +78,7 @@ Adding Your Tool to the IUC Repository
   previous sections of this document), add your tool and all associated data,
   then Commit the changes with ``git commit -m "I changed X, Y, and Z"``. Finally push your changes to github with ``git push origin $branch_name``.
 - Go to the `IUC's Repository <https://github.com/galaxyproject/tools-iuc>`__ and click on 'Compare & Pull Request'.
-- Add a comment describing what the tool does and any extra information that might
+- Fill the Pull Request description describing what the tool does and any extra information that might
   be needed (E.g. "I had some trouble with the data tables, can someone please
   double check them").
 - The IUC will review your tool for inclusion.

--- a/docs/best_practices/package_xml.rst
+++ b/docs/best_practices/package_xml.rst
@@ -19,8 +19,9 @@ Reference a Bioconda/conda-forge package by name and version, e.g.
         <requirement type="package" version="1.2.36">aragorn</requirement>
     </requirements>
 
-Pin the version with a ``@TOOL_VERSION@`` macro token and reuse it in the
-``<requirement>`` as described in :doc:`tool_xml`.
+If the Galaxy tool is a wrapper for an underlying tool, pin the version with a
+``@TOOL_VERSION@`` macro token and reuse it in the ``<requirement>`` as
+described in :doc:`tool_xml`.
 
 If a package does not yet exist
 -------------------------------
@@ -30,8 +31,9 @@ Search `Bioconda <https://bioconda.github.io/>`__ and `conda-forge
 dependency. If not, create a recipe: the Conda recipe (``meta.yaml``) carries
 the download URL and a ``sha256`` checksum, so installs are integrity-checked
 and reproducible. Consider announcing your packaging effort on the
-`tools-iuc Matrix channel <https://matrix.to/#/#galaxy-iuc_iuc:gitter.im>`__ so
-others can help or avoid duplicating work.
+`Bioconda Matrix channel <https://matrix.to/#/#bioconda_Lobby:gitter.im>`__ so
+others can help or avoid duplicating work. For Galaxy wrapper questions, use the
+`tools-iuc Matrix channel <https://matrix.to/#/#galaxy-iuc_iuc:gitter.im>`__.
 
 Learn more
 ----------


### PR DESCRIPTION
## Summary

- clarify that `@TOOL_VERSION@` applies when a Galaxy tool wraps an underlying tool
- direct package-development coordination to the Bioconda Matrix channel while retaining `tools-iuc` for Galaxy wrapper questions
- tell contributors to fill in the Pull Request description instead of adding an unspecified comment

## Context

This is a focused follow-up to @nsoranzo's review of #84, which was merged while the review was still in progress. Thanks, Nicola, for the suggestions.

## Impact

The dependency and contribution guidance now directs developers to the right support channel and more precisely describes when the version macro and Pull Request description guidance apply.

## Validation

- `.venv/bin/sphinx-build -W -b html docs docs/_build/html`
