### PR TITLE
Add Remote Execution and Tool Security checklists, CI docs

### DIFF
--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -46,6 +46,20 @@ Tools and Tool Development
     best_practices/tool_xml
     best_practices/integration_checklist
 
+Tool Security Checklist
+-----------------------
+
+.. toctree::
+
+    best_practices/security
+
+Remote Execution Checklist
+--------------------------
+
+.. toctree::
+
+    best_practices/pulsar
+
 Packages
 --------
 
@@ -74,4 +88,3 @@ Repository Management
 .. toctree::
 
     best_practices/management
-

--- a/docs/best_practices/integration_checklist.rst
+++ b/docs/best_practices/integration_checklist.rst
@@ -27,6 +27,7 @@ Creating the Tool Wrapper (XML File)
 - Add a short tool `Description <http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#tool-descriptions>`__.
 - Fill in the `Requirements <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-requirements>`__ section with the conda package name and version number for the tool and its dependencies.
 - Add the `Version Command <https://docs.galaxyproject.org/en/master/dev/schema.html#tool-version-command>`__ that specifies the command to get the tool’s version.
+- Review the :doc:`Tool Security Checklist <security>` and trace every user-controlled value through Cheetah, the generated command, helper scripts, files, network clients, and rendered outputs.
 - Add the `Command <http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#command-tag>`__ section. The command to run the tool must be within `CDATA tags <https://en.wikipedia.org/wiki/CDATA>`__, written in `Cheetah <http://cheetahtemplate.org/>`__ and conform to `PEP 8 <http://pep8.org/>`__. You should add `Exit Code detection <http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#exit-code-detection>`__ and **use single quotes** for all Input and Output parameters of type ``data``, ``data_collection`` and ``text``.
 - Supply at least one `Input <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-inputs>`__ with a description of parameters. Add `Validators <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-inputs-param-validator>`__ to user input fields.
 - Supply at least one `Output <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-outputs>`__ with a description of parameters. For Output that is optionally created, use `Filters <https://docs.galaxyproject.org/en/master/dev/schema.html#tool-outputs-data-filter>`__.
@@ -82,4 +83,4 @@ Adding Your Tool to the IUC Repository
   be needed (E.g. "I had some trouble with the data tables, can someone please
   double check them").
 - The IUC will review your tool for inclusion.
-- Note that any Python code submitted to IUC must conform to `PEP 8 <http://pep8.org/>`__, in order to pass the `flake8 <http://flake8.pycqa.org/en/latest/>`__ `Travis CI <https://travis-ci.org/>`__ testing.
+- Note that any Python code submitted to IUC must conform to `PEP 8 <https://pep8.org/>`__, in order to pass the `flake8 <https://flake8.pycqa.org/en/latest/>`__ linting run by the IUC's GitHub Actions CI.

--- a/docs/best_practices/management.rst
+++ b/docs/best_practices/management.rst
@@ -14,4 +14,4 @@ Automated Management
 
 The IUC has developed GitHub Actions configurations in order to assist in
 continually synchronizing your GitHub repository with the toolshed components.
-You can view these in `.github/workflows in the IUC's GitHub Repo <https://github.com/galaxyproject/tools-iuc/blob/master/.github/workflows>`__
+You can view these in `.github/workflows in the IUC's GitHub Repo <https://github.com/galaxyproject/tools-iuc/blob/main/.github/workflows>`__

--- a/docs/best_practices/package_xml.rst
+++ b/docs/best_practices/package_xml.rst
@@ -35,6 +35,32 @@ and reproducible. Consider announcing your packaging effort on the
 others can help or avoid duplicating work. For Galaxy wrapper questions, use the
 `tools-iuc Matrix channel <https://matrix.to/#/#galaxy-iuc_iuc:gitter.im>`__.
 
+Multi-requirement containers
+----------------------------
+
+A tool with a single requirement gets its BioContainer automatically. Tools that
+combine *multiple* requirements need a "mulled" container bundling that specific
+combination, and those are not built until the combination has been registered.
+
+The `planemo-monitor <https://github.com/galaxyproject/planemo-monitor>`__
+repository automates that registration on behalf of the community. A scheduled
+GitHub Actions workflow (`monitor.yaml
+<https://github.com/galaxyproject/planemo-monitor/blob/master/.github/workflows/monitor.yaml>`__)
+runs once a day. For every repository it tracks, it runs
+``planemo container_register --recursive`` on it, which walks all of the tools,
+collects each multi-requirement combination, and - for any combination not
+already published or already pending - opens a pull request against
+`BioContainers/multi-package-containers
+<https://github.com/BioContainers/multi-package-containers>`__. Once that pull
+request is merged, the multi-package-containers CI builds the mulled container
+and publishes it to quay.io, from where Galaxy can pull it to execute the tool
+in a container.
+
+To have your own tools covered, add your repository's clone URL to one of the
+``repositories*.list`` files in planemo-monitor via a pull request. From then on
+your multi-requirement tools will have their containers registered and built
+automatically, with no further action required on your part.
+
 Learn more
 ----------
 

--- a/docs/best_practices/pulsar.rst
+++ b/docs/best_practices/pulsar.rst
@@ -1,0 +1,238 @@
+Remote Execution Checklist
+==========================
+
+`Pulsar <https://pulsar.readthedocs.io/>`__ runs Galaxy jobs on a remote
+compute resource that does **not** share a filesystem with the Galaxy server.
+Most tools "just work", but a handful of authoring habits quietly assume that
+the server's filesystem is the job's filesystem — and those break only when the
+tool is finally run through Pulsar on a production Galaxy server.
+
+The unifying principle behind every item below:
+
+    The Cheetah ``<command>`` template and job setup are evaluated on the
+    Galaxy **head node**, but the job runs on a **remote filesystem** with
+    different paths and a possibly empty view of the tool directory, reference
+    data, and outputs. Assume nothing about shared paths.
+
+The Checklist
+-------------
+
+#. :ref:`Declare every tool-directory file with \<required_files\> <pulsar-required-files>`
+   — anything sourced, imported, or copied in, the entry script itself, and not
+   just what is named on the command line.
+#. :ref:`No filesystem I/O in Cheetah templates <pulsar-no-fs-io>`
+   — use dataset metadata, never ``os.path``/``open`` on data paths.
+#. :ref:`Do not reach into $__app__ at template time <pulsar-data-tables>`
+   — discouraged for tools generally; use ``from_data_table`` + ``.fields.path`` for reference data.
+#. :ref:`No hardcoded absolute paths <pulsar-no-abs-paths>`
+   — to reference data, indexes, scratch, or ``/tmp``.
+#. :ref:`Outputs must be real files inside the job output directory <pulsar-outputs-in-jobdir>`
+   — never symlink an output to an input or outside the job tree.
+#. :ref:`Keep discovered outputs inside the job working directory <pulsar-discovered-outputs>`
+   — ``discover_datasets`` / ``from_work_dir`` / collection discovery stage back only from the job tree.
+
+Details
+-------
+
+.. _pulsar-required-files:
+
+1. Declare every tool-directory file with ``<required_files>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pulsar stages a tool's own files to the remote node only if it can determine
+they are needed. Historically it inferred this from the command line: a helper
+named directly in ``<command>`` (``python '$__tool_directory__/foo.py'``) gets
+transferred, but a file pulled in *indirectly* — ``source()``\ d, ``import``\ ed,
+or ``include``\ d by another script — is invisible to that scan and is missing
+on the node. The symptom is always ``No such file or directory`` / ``can't stat``
+at job runtime.
+
+Declare such files explicitly so staging is deterministic and author-controlled.
+This matters most when a file is *not* named on the command line.
+
+A Python tool that shells out to helper scripts (`virAnnot_otu
+<https://github.com/galaxyproject/tools-iuc/blob/a4c4c8ca75e888ea04c4a93b35b4650dcc85e5d5/tools/virannot/virAnnot_otu.xml>`__)
+runs ``python '$__tool_directory__/otu.py' … -tp '$__tool_directory__/'`` but
+reaches its helpers at runtime with
+``os.path.join(tool_path, 'seek_otu.R')`` and ``os.path.join(tool_path, 'rps2tree_html.py')`` —
+so those two never appear on the command line and all three files must be
+declared:
+
+.. code-block:: xml
+
+    <required_files>
+        <include path="otu.py" />
+        <include path="seek_otu.R" />
+        <include path="rps2tree_html.py" />
+    </required_files>
+
+An R tool that sources a shared utility library (`ggplot2_barplot
+<https://github.com/galaxyproject/tools-iuc/blob/a4c4c8ca75e888ea04c4a93b35b4650dcc85e5d5/tools/ggplot2/ggplot2_barplot.xml>`__)
+runs ``Rscript -e 'source("${__tool_directory__}/utils.r")' -e 'source("${run_script}")'``.
+Here ``utils.r`` holds shared helper functions (``load_data()`` and friends) while
+the analysis itself is a generated ``run_script`` configfile — so the sourced
+library must be declared:
+
+.. code-block:: xml
+
+    <required_files>
+        <include path="utils.r" />
+    </required_files>
+
+.. _pulsar-required-files-correct:
+
+**Getting the declaration right.** Most real-world failures are not a missing
+block — they are a subtly incomplete one:
+
+- **Declare the entry script too**, not only its helpers. Some tools declare a
+  ``_utils.py`` but not the main script that ``$__tool_directory__`` runs.
+- **Use the correct relative path** (relative to the tool directory). A file
+  declared at the wrong location stages nothing.
+- **Declare files you copy into the working directory** (``cp
+  '$__tool_directory__/x' .``), not only the ones you execute directly.
+- **Drop dead includes** — a declared file that is never referenced is just
+  staging overhead and a maintenance trap.
+
+For example, `table_compute
+<https://github.com/galaxyproject/tools-iuc/blob/a4c4c8ca75e888ea04c4a93b35b4650dcc85e5d5/tools/table_compute/table_compute.xml>`__
+copies its scripts into the working directory (a soft link does not satisfy a
+Python ``import``), so *both* copied files must be declared even though only one
+is invoked directly:
+
+.. code-block:: xml
+
+    <required_files>
+        <include path="scripts/safety.py" />
+        <include path="scripts/table_compute.py" />
+    </required_files>
+
+.. code-block:: shell
+
+    cp '$__tool_directory__/scripts/safety.py' ./safety.py &&
+    cp '$__tool_directory__/scripts/table_compute.py' ./table_compute.py &&
+    python ./table_compute.py
+
+.. _pulsar-no-fs-io:
+
+2. No filesystem I/O in Cheetah templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The template runs on the Galaxy server, so opening or stat-ing a data file by
+path uses the *server's* path — which is wrong or nonexistent when the
+destination is Pulsar. At template time ``$input`` is a remote path string; do
+not feed it to Python file I/O.
+
+.. code-block:: none
+
+    ## WRONG — raises on the server; the path is remote
+    #set size = $os.path.getsize(str($in_file))
+
+    ## RIGHT — metadata Galaxy already knows, no filesystem access
+    #set size = $in_file.get_size()
+
+Use dataset metadata (``.get_size()``, ``.metadata.*``, ``.element_identifier``,
+``.is_of_type(...)``) instead of ``open`` / ``os.path`` / ``os.stat`` /
+``os.listdir`` on data paths.
+
+**When metadata is not enough, defer to runtime.** Sometimes you genuinely need
+to list a directory, glob a set of produced files, or read a file's contents —
+metadata cannot answer that. The fix is *not* to do it in the template; it is to
+do it in the part of the job that runs **on the node**, where the files actually
+exist. The shell ``<command>`` body and any ``<configfile>`` script execute
+remotely, so the very call that is fatal in a Cheetah ``#set`` is correct there.
+
+The cleanest contrast is a Python glob. In a Cheetah template it stats the
+server's filesystem and breaks under Pulsar; moved into a ``<configfile>`` (as in
+`snapatac2
+<https://github.com/galaxyproject/tools-iuc/blob/a4c4c8ca75e888ea04c4a93b35b4650dcc85e5d5/tools/snapatac2/dimension_reduction_clustering.xml>`__)
+the identical code runs on the node against files that are really present:
+
+.. code-block:: python
+
+    ## In a <configfile> — runs on the node, the files exist here
+    import glob
+    files = sorted(glob.glob('adata_*.h5ad'))
+
+Only the *rendered* content runs remotely: a ``<configfile>`` is still
+Cheetah-rendered on the Galaxy server before it is staged. ``import glob`` above
+is plain text that Cheetah passes through, but ``#set files = os.listdir(...)``
+in the same file is a Cheetah directive and still runs on the head node.
+
+Equivalently, let the job shell expand the glob rather than listing directories
+at template time (`prinseq
+<https://github.com/galaxyproject/tools-iuc/blob/a4c4c8ca75e888ea04c4a93b35b4650dcc85e5d5/tools/prinseq/prinseq.xml>`__,
+`macs2
+<https://github.com/galaxyproject/tools-iuc/blob/a4c4c8ca75e888ea04c4a93b35b4650dcc85e5d5/tools/macs2/macs2_callpeak.xml>`__):
+
+.. code-block:: shell
+
+    ## enumerate outputs on the node — never os.listdir() on the head node
+    for f in tmp/*.fastq; do gzip -c "$f" > tmp_file && mv tmp_file "$f"; done
+
+.. _pulsar-data-tables:
+
+3. Do not reach into ``$__app__`` at template time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``$__app__`` exposes Galaxy's live internal application object inside the
+Cheetah template. Reaching into it is discouraged as a general tool-authoring
+practice — independent of Pulsar — because it couples the tool to Galaxy's
+runtime internals and server-specific configuration: it sidesteps the parameter
+machinery, is not portable or reproducible across servers, and rides on internal
+APIs that are not part of the stable tool contract. A well-behaved tool's
+command line should be a function of its *declared inputs*, not of server state.
+
+One ``$__app__`` paradigm is especially toxic for Pulsar. Reaching into
+``$__app__.tool_data_tables[...].get_fields()`` and materializing a path in the
+template bakes a *server-side* absolute path into the command line — which
+Pulsar will not rewrite, so the job fails on a node that has a different (or no)
+view of that path. Let Galaxy resolve the path through normal, Pulsar-aware
+handling instead:
+
+.. code-block:: xml
+
+    <param name="reference" type="select" label="Reference genome">
+        <options from_data_table="my_index" />
+    </param>
+
+and reference ``$reference.fields.path`` directly on the command line — do not
+``str()``-materialize it into an intermediate ``#set``.
+
+.. _pulsar-no-abs-paths:
+
+4. No hardcoded absolute paths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Absolute paths to reference data, indexes, scratch, or ``/tmp`` will not exist
+on the remote node and will not be rewritten. Route reference data through a
+data table so the path is a rewritable handle rather than a literal.
+
+Whether that data is actually *present* on the compute node (typically via
+CVMFS or a shared mount) is a deployment concern for the Pulsar operator, not a
+tool-XML bug — but the tool's part of the bargain is to never bake in an
+absolute path.
+
+.. _pulsar-outputs-in-jobdir:
+
+5. Outputs must be real files inside the job output directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every output — including composite datasets and ``extra_files_path`` contents —
+must be a real file written inside the job's output directory. Never
+``ln -s`` an output (or an entry in its files-path) to an input dataset, a
+reference path, or anything outside the job working directory.
+
+Pulsar's staging guard rejects a path that resolves outside the authorized job
+directory, and the symlink is fragile even locally — it dangles as soon as the
+input dataset is purged or moved. Remote execution simply surfaces a latent bug.
+
+.. _pulsar-discovered-outputs:
+
+6. Keep discovered outputs inside the job working directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The same principle as item 5, seen from the discovery angle.
+``discover_datasets``, ``from_work_dir``, and ``<collection>`` discovery all
+stage results back reliably **provided the files land inside the job working
+directory** (or a ``directory=`` subdirectory under it). Outputs written to an
+absolute path or outside the job tree are never staged back, by design.

--- a/docs/best_practices/security.rst
+++ b/docs/best_practices/security.rst
@@ -1,0 +1,372 @@
+Tool Security Checklist
+=======================
+
+Galaxy tool wrappers sit at a trust boundary. Values supplied through tool
+parameters, datasets, collection identifiers, metadata, uploaded files, and
+credentials may reach shells, generated scripts, filenames, deserializers,
+remote services, or browser-rendered output.
+
+The unifying principle behind every item below:
+
+    Treat every user-controlled value as data. Track how it is transformed and
+    where it is consumed. Quoting, validation, and sanitization are
+    context-specific controls, not interchangeable guarantees.
+
+The Checklist
+-------------
+
+#. :ref:`Single-quote dynamic values in shell commands <security-shell-quoting>`
+   — quote text, data paths, collection values, input and output paths, and inspect nested shell contexts separately.
+#. :ref:`Constrain free text to the smallest useful language <security-free-text>`
+   — prefer typed parameters and selects; otherwise use validators and a deliberately narrow sanitizer.
+#. :ref:`Treat identifiers and generated filenames as untrusted <security-identifiers>`
+   — quote identifiers for the shell and normalize them before filesystem use without creating collisions.
+#. :ref:`Preserve sanitization through Cheetah expressions <security-sanitizer-semantics>`
+   — do not assume that method calls, joins, or Python expressions sanitize wrapped parameter values.
+#. :ref:`Keep Cheetah templating side-effect free <security-cheetah-side-effects>`
+   — template evaluation runs with Galaxy's privileges before the job or container starts.
+#. :ref:`Keep user values as data, never generated code <security-data-not-code>`
+   — use config files, JSON, or strict allowlists instead of ``eval``, user scripts, or interpolated program text.
+#. :ref:`Treat uploaded serialized objects and archives as active input <security-unsafe-formats>`
+   — pickle-like formats may execute code and archive extraction may write outside the job directory.
+#. :ref:`Keep credentials out of commands, arguments, and logs <security-credentials>`
+   — use Galaxy credentials and an application's native environment- or file-based interface.
+#. :ref:`Verify downloads and preserve transport security <security-downloads>`
+   — require TLS verification, prefer immutable sources, and check downloaded content before use.
+#. :ref:`Treat browser-rendered output as active content <security-active-content>`
+   — raw HTML, SVG, and JavaScript require an explicit trust and containment decision.
+
+Details
+-------
+
+.. _security-shell-quoting:
+
+1. Single-quote dynamic values in shell commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``<command>`` block is rendered into a script and executed by a shell.
+Text parameters, dataset paths, output paths, metadata, and collection values
+can contain whitespace or shell metacharacters. Place each dynamic value in
+single quotes so the shell receives one literal argument:
+
+.. code-block:: xml
+
+    <!-- WRONG: word splitting and shell expansion are possible. -->
+    my_tool --input $input --label "$label" --output $output
+
+    <!-- RIGHT: each value is one literal shell argument. -->
+    my_tool --input '$input' --label '$label' --output '$output'
+
+**Double quotes are not equivalent to single quotes**: the shell still performs
+parameter expansion, command substitution, and some backslash processing
+inside double quotes. Numeric parameters and fixed ``select`` values can be
+different, but the safety argument must come from their type or finite value
+set, not from visual similarity to a text parameter.
+
+Quoting must match the actual interpreter. A value placed inside
+``bash -c``, an ``awk`` program, an R or Python expression, or a generated
+script crosses another parsing boundary. Quoting it once for the outer shell
+does not make it safe for the inner language. The safer design is usually to
+write values to a Galaxy ``<configfile>`` and have the program consume them as
+data.
+
+.. _security-free-text:
+
+2. Constrain free text to the smallest useful language
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``integer``, ``float``, ``boolean``, ``select``, ``data_column``, and other
+typed parameters when they describe the real input domain. A free-text
+parameter gives a user a much larger language than most command-line options
+need.
+
+When text is required:
+
+- Add a validator that rejects values outside the tool's accepted language.
+  Galaxy regex validators match from the beginning, so anchor the end as well
+  when the complete value must be constrained.
+- Use a sanitizer that preserves only the characters the application needs.
+  Do not start from ``string.printable`` unless the downstream representation
+  safely supports every allowed character.
+- Give validators a useful message so rejected input can be corrected.
+- Test punctuation, whitespace, quotes, newlines, empty values, and boundary
+  lengths, not only the default.
+
+For example, when a sample label must contain only letters, digits,
+underscores, and hyphens:
+
+.. code-block:: xml
+
+    <!-- WRONG: this prefix match also accepts "sample;unexpected". -->
+    <param name="sample_name" type="text">
+        <validator type="regex">[A-Za-z0-9_-]+</validator>
+    </param>
+
+    <!-- RIGHT: the anchors constrain the complete value. -->
+    <param name="sample_name" type="text">
+        <validator type="regex"
+                   message="Use only letters, digits, underscores, and hyphens.">^[A-Za-z0-9_-]+$</validator>
+    </param>
+
+This validation complements, but does not replace, quoting at a shell boundary.
+If the valid values form a finite set, use a ``select`` instead of free text.
+
+Validators and sanitizers do different work. A validator rejects an invalid
+value before the job starts. A sanitizer transforms characters as the value is
+rendered. Silent transformation can corrupt a regular expression, sample name,
+or scientific identifier, while validation can preserve the original value
+and explain why it is not accepted.
+
+The default sanitizer is a character transformation, not shell escaping; its
+allowed set includes several characters with shell meaning. A custom sanitizer
+that permits a single quote also invalidates the usual ``'$value'`` shell
+boundary unless that quote is handled separately.
+
+Galaxy's schema reference documents both
+`validators <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-inputs-param-validator>`__
+and
+`sanitizers <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-inputs-param-sanitizer>`__.
+
+.. _security-identifiers:
+
+3. Treat identifiers and generated filenames as untrusted
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``element_identifier``, dataset names, metadata values, and labels are
+user-influenced strings. They are not safe merely because Galaxy supplied
+them. Galaxy generally works to sanitize these values, but the best practice
+is still to treat them as untrusted. IUC reviews repeatedly find identifiers
+used as symlink names, temporary paths, output prefixes, or fragments of
+generated command files.
+
+Two independent controls may be required:
+
+#. **Shell safety:** single-quote the final path whenever it enters a shell
+   command.
+#. **Filesystem safety:** map the identifier to a deliberately small filename
+   alphabet before creating a file, directory, or link.
+
+.. code-block:: xml
+
+    <!-- WRONG: the raw identifier controls a filename and is unquoted. -->
+    ln -s '$input' $input.element_identifier
+
+    <!-- RIGHT when the external tool does not need the original identifier. -->
+    ln -s '$input' input.fasta
+
+    <!-- RIGHT when the external tool requires a meaningful filename. -->
+    #import re
+    #set identifier = str($input.element_identifier)
+    #set safe_identifier = re.sub(r'[^\w.-]', '_', identifier)
+    ln -s '$input' '${safe_identifier}.fasta'
+
+If the external program does not need the original identifier, prefer a fixed
+filename. If it does, preserve the original value separately in data or
+metadata. A replacement such as ``re.sub('[^\\w.-]', '_', value)`` can cause
+different identifiers to collapse to the same filename; add a stable unique
+suffix or fail on collisions when multiple collection elements are handled
+together.
+
+.. _security-sanitizer-semantics:
+
+4. Preserve sanitization through Cheetah expressions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Galaxy wraps parameter values so their string representation is sanitized
+when Cheetah renders them. That protection is not a license to perform
+arbitrary Python operations on wrapped values.
+
+Be especially careful with:
+
+- ``.split()``, ``.strip()``, and other method calls inside ``#set`` or
+  ``#echo`` expressions;
+- joining lists derived from text parameters;
+- formatting strings that combine parameters into shell fragments;
+- directly accessing an unsanitized or internal representation;
+- disabling sanitization and assuming surrounding quotes compensate.
+
+When transforming a text parameter in Cheetah, explicitly convert the
+parameter to ``str`` *before* calling methods such as ``split`` or ``strip``,
+then quote each resulting shell argument. In
+2025, a single IUC change had to add explicit ``str(...)`` conversions across
+13 wrappers because Python-expression use bypassed the expected sanitizer.
+
+Do not reduce this rule to "add ``str`` everywhere": the desired result is
+that the value is sanitized exactly once for the context where it is consumed.
+Values written to JSON or another data-only config may legitimately preserve
+characters that would be unsafe in a shell fragment.
+
+.. _security-cheetah-side-effects:
+
+5. Keep Cheetah templating side-effect free
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Galaxy evaluates Cheetah in ``<command>`` and templated ``<configfile>`` blocks
+on the Galaxy server while preparing the job. This happens before the command
+runs and therefore before a job container or remote execution environment can
+isolate it.
+
+Do not use template expressions to:
+
+- open, write, list, or stat server files;
+- import and call ``os``, ``pathlib``, ``subprocess``, or network clients;
+- query internal application objects such as ``$__app__``;
+- access an unsanitized internal parameter representation;
+- perform work that belongs in the job command or a declared helper script.
+
+Use Galaxy dataset metadata rather than opening an input path during template
+evaluation. Put runtime work in a tool dependency or a reviewed helper that
+runs as part of the job.
+
+This is both a security and remote-execution rule. Standard tool templates have
+access to Galaxy's process environment and filesystem; a container around the
+eventual command does not contain template-phase behavior. Galaxy's
+`user-defined tool security documentation
+<https://docs.galaxyproject.org/en/latest/admin/user_defined_tools.html>`__
+describes why untrusted XML/Cheetah tools cannot be treated as ordinary
+user-authored jobs.
+
+.. _security-data-not-code:
+
+6. Keep user values as data, never generated code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avoid inserting user-controlled values into Python, R, JavaScript, ``awk``,
+regular-expression replacement programs, or arbitrary shell snippets.
+Quoting rules are different for every language and become difficult to reason
+about when interpreters are nested.
+
+Prefer:
+
+- a Galaxy ``<configfiles><inputs .../>`` typed JSON document, or a templated
+  ``<configfile>`` only when the target format is consumed strictly as data;
+- a tabular key/value file parsed by the wrapped application;
+- fixed commands selected with a ``select`` parameter;
+- a narrow, explicit allowlist when expression support is the purpose of the
+  tool.
+
+Do not expose ``eval``, ``exec``, user-provided script bodies, arbitrary
+command options, or "run your own command" escape hatches in a general-purpose
+wrapper. If controlled expression evaluation is unavoidable, define allowlists for names,
+operators, attributes, and call targets, then test bypasses such as attribute
+traversal and unexpected object types.
+
+Galaxy documents generated
+`config files and JSON input files <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-configfiles>`__,
+which keep values out of command syntax and make the data boundary reviewable.
+A templated config file can also generate Python, R, shell, or another
+executable language; scan it according to that target grammar rather than
+assuming every config file is safe.
+
+.. _security-unsafe-formats:
+
+7. Treat uploaded serialized objects and archives as active input
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some formats are executable representations rather than passive data.
+Python pickle, RData/RDS objects, and some machine-learning checkpoint formats
+can construct objects or invoke code while loading. A datatype extension does
+not make an uploaded object trustworthy.
+
+Before accepting such an input:
+
+- determine whether the library has a restricted or data-only loading mode;
+- prefer an interchange format that cannot encode executable objects;
+- limit loading to tool-produced outputs when provenance can be enforced;
+- document that public, multi-user Galaxy deployments have a different threat
+  model from private trusted-user installations;
+- treat a container as damage containment, not proof that deserialization is
+  safe.
+
+Archive extraction is a related boundary. Validate each member's resolved
+destination before extraction, reject absolute paths and ``..`` traversal, and
+consider links and special files. Extract only the members the tool actually
+needs.
+
+.. _security-credentials:
+
+8. Keep credentials out of commands, arguments, and logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Passwords, API keys, access tokens, and private endpoints must not appear in:
+
+- literal tool XML or test fixtures;
+- generated command text or Galaxy job metadata;
+- command-line arguments visible in the process list;
+- ``echo`` statements, standard output, standard error, or debug logs;
+- output datasets or test assertions.
+
+Galaxy 25.1 introduced ``<credentials>`` requirements that inject variables
+and secrets into the job environment without making them Cheetah variables.
+Use an application's native environment-variable lookup when it does not copy
+the value onto the command line. If the application accepts a credential file,
+use a runtime helper that reads the environment and creates a private file with
+restrictive permissions, then pass only the file path. Do not use an ordinary
+templated ``<configfile>`` for a secret: credentials are intentionally not
+Cheetah variables, and ordinary generated config files are not secret storage.
+
+Do not expand a secret-bearing environment variable as a command-line
+argument. Besides process-list exposure, Galaxy's credential values are not
+sanitized for shell use. Document the remaining exposure: job scripts may be
+visible to Galaxy administrators, depending on deployment retention and
+access policy.
+
+See the Galaxy schema's
+`credential security considerations
+<https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-requirements-credentials>`__.
+
+.. _security-downloads:
+
+9. Verify downloads and preserve transport security
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Data Managers and tools that fetch remote content extend the trust boundary to
+another service.
+
+- Use HTTPS and do not disable hostname or certificate verification.
+- Prefer versioned, immutable URLs over branch heads or "latest" endpoints.
+- Verify a checksum obtained through an independent, trusted channel.
+- Fail the job on verification errors; do not continue with partial content.
+- Avoid executing a downloaded script or unpacking an archive before
+  verification.
+- Record the source URL and version in the resulting data-table entry or
+  provenance where possible.
+- Do not pass an unconstrained user URL directly to ``curl``, ``wget``, or a
+  language HTTP client. Restrict schemes and hosts, reject local/private
+  destinations and embedded credentials, re-check redirects, and limit size
+  and time. Direct wrapper downloads bypass Galaxy's own URL-fetch allowlist
+  and private-network protections.
+
+A checksum detects corruption or substitution relative to the expected
+artifact; it does not establish that the upstream artifact itself is benign.
+Dependency versions and containers should also remain pinned according to the
+tool dependency best practices.
+
+.. _security-active-content:
+
+10. Treat browser-rendered output as active content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+HTML, SVG, and JavaScript can execute in a browser or load remote resources.
+Do not publish raw active content merely because it is convenient for
+presenting a report.
+
+Prefer Galaxy-native datasets and collections, static images, or a narrowly
+defined format that Galaxy can render through an established safe path. When
+active content is essential, identify which values are user controlled,
+escape them for the correct HTML/attribute/URL/JavaScript context, apply the
+Galaxy rendering and isolation mechanisms intended for that datatype, and
+document the trust decision.
+
+Galaxy's safe defaults sanitize HTML unless an administrator allowlists the
+tool, and serve SVG/XML-like XSS-prone content as plain text unless an
+administrator enables active serving. Emitting active content therefore creates
+an administrator trust decision; a wrapper must not assume every deployment
+keeps the same rendering policy.
+
+See Galaxy's
+`HTML sanitization option
+<https://docs.galaxyproject.org/en/latest/admin/galaxy_options.html#sanitize-all-html>`__
+and
+`XSS-vulnerable MIME-type option
+<https://docs.galaxyproject.org/en/latest/admin/galaxy_options.html#serve-xss-vulnerable-mimetypes>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,19 +9,43 @@ community, both for contributing back to the
 `IUC repository <https://github.com/galaxyproject/tools-iuc/>`__ and for use in
 their own tool repositories.
 
-.. grid:: 2
+Checklists
+----------
 
-    .. grid-item-card:: Tool XML
-        :link: best_practices/tool_xml
-        :link-type: doc
+Step-by-step lists to work through when preparing a tool.
 
-        Structure, macros, command sections, tests, and help for tool wrappers.
+.. grid:: 1 2 3 3
 
     .. grid-item-card:: Integration Checklist
         :link: best_practices/integration_checklist
         :link-type: doc
 
         A step-by-step checklist for getting a tool ready for the Tool Shed.
+
+    .. grid-item-card:: Tool Security Checklist
+        :link: best_practices/security
+        :link-type: doc
+
+        A security checklist for wrappers, inputs, commands, files, credentials, and downloads.
+
+    .. grid-item-card:: Remote Execution Checklist
+        :link: best_practices/pulsar
+        :link-type: doc
+
+        A checklist for making tools work when jobs run remotely without a shared filesystem.
+
+Documentation
+-------------
+
+Reference guides for the pieces that make up a tool and its repository.
+
+.. grid:: 1 2 3 3
+
+    .. grid-item-card:: Tool XML
+        :link: best_practices/tool_xml
+        :link-type: doc
+
+        Structure, macros, command sections, tests, and help for tool wrappers.
 
     .. grid-item-card:: Tool Dependencies
         :link: best_practices/package_xml


### PR DESCRIPTION
Checklists-only redo of the pulsar (#85) and repositories (#86) branches, without the "Corpus Research (AI Generated)" deep-dives or links to them.

- Remote Execution Checklist (docs/best_practices/pulsar.rst): 7 items on required_files, Cheetah template I/O, data tables, absolute paths, and outputs staying in the job dir. Links to IUC exemplars pinned to a fixed tools-iuc commit.
- Tool Security Checklist (docs/best_practices/security.rst): 10 items on command construction, sanitization, serialization, credentials, downloads, and browser-rendered output.
- CI walkthrough (docs/best_practices/pr_yaml.rst) of the IUC pr.yaml workflow; planemo-monitor container registration in management.rst; integration checklist Travis CI -> GitHub Actions; tools-iuc master -> main.
- Landing page split into Checklists and Documentation card groups.

Dropped vs the earlier branches: docs/best_practices/{pulsar,security}/*.md research notes, their "Further reading" sections, and the .claude/commands/iuc-security-audit.md command that regenerates them.